### PR TITLE
feat: LLM-generated confirmation prompts (Gemma writes the OSD hint)

### DIFF
--- a/src/korder/app.py
+++ b/src/korder/app.py
@@ -158,6 +158,7 @@ def _run_app() -> int:
     op_parser = None
     op_parser_is_warm = None
     op_parser_warm_up = None
+    confirm_prompt_generator = None
     if cfg["inject"]["action_parser"].lower() == "llm":
         from korder.intent import IntentParser
         thinking = _bool(cfg["intent"]["thinking_mode"])
@@ -180,6 +181,13 @@ def _run_app() -> int:
         op_parser = intent_parser.parse
         op_parser_is_warm = intent_parser.is_model_loaded
         op_parser_warm_up = intent_parser.warm_up
+        confirm_prompt_generator = intent_parser.generate_confirm_prompt
+        # Pre-generate confirmation prompts for all confirmable actions
+        # in the current locale, so the first time the user triggers
+        # one (shutdown, reboot, sleep) the OSD's hint update is
+        # instant rather than paying the ~500ms LLM round-trip.
+        from korder.ui.i18n import current_locale
+        intent_parser.warm_feedback_cache(current_locale())
         flags = []
         if thinking:
             flags.append("thinking")
@@ -231,6 +239,7 @@ def _run_app() -> int:
         ducker=ducker,
         wake_detector=wake_detector,
         wake_idle_timeout_s=wake_idle_timeout_s,
+        confirm_prompt_generator=confirm_prompt_generator,
     )
 
     tray = _make_tray(window)

--- a/src/korder/intent.py
+++ b/src/korder/intent.py
@@ -144,6 +144,12 @@ class IntentParser:
         # when thinking_mode is on. Surfaced for diagnostics (logged to
         # stderr in _call_ollama; readable by the benchmark dialog).
         self.last_thinking: str = ""
+        # Cache of LLM-generated user-facing strings, keyed on
+        # (kind, action_name, locale). Each entry is generated once
+        # per app session via _call_ollama_completion; subsequent
+        # lookups hit instantly. Sized small (≤20 actions × 2 locales
+        # × handful of kinds) so no eviction logic needed.
+        self._feedback_cache: dict[tuple[str, str, str], str] = {}
 
     def warm_up(self) -> None:
         """Fire-and-forget: tell ollama to page the model into VRAM,
@@ -215,6 +221,115 @@ class IntentParser:
             if m.get("name") == self.model or m.get("model") == self.model:
                 return True
         return False
+
+    def warm_feedback_cache(self, locale: str = "en") -> None:
+        """Pre-generate confirmation prompts for every action that has a
+        'confirm' parameter, in the given locale, on a background
+        thread. Idempotent — skips cached entries. Called once at app
+        boot so the first time the user triggers a confirmable action,
+        the cached prompt is already there and the OSD update is
+        instant.
+
+        Generation is serial (not parallel) so we don't overload the
+        ollama queue — each completion is ~300-500ms and there are
+        only a handful of confirmable actions, so total is ~1-2s
+        running alongside whatever else happens at startup.
+        """
+        confirmable = [a for a in all_actions() if "confirm" in a.parameters]
+        if not confirmable:
+            return
+        def _populate() -> None:
+            for action in confirmable:
+                if ("confirm", action.name, locale) in self._feedback_cache:
+                    continue
+                # Side-effect of generate_confirm_prompt is to populate
+                # the cache; we ignore the return.
+                self.generate_confirm_prompt(action.name, locale)
+        threading.Thread(target=_populate, daemon=True).start()
+
+    def generate_confirm_prompt(
+        self,
+        action_name: str,
+        locale: str = "en",
+    ) -> str | None:
+        """Ask the LLM to phrase a natural confirmation question for a
+        destructive action, in the user's locale. Returns None if the
+        LLM call fails or the action isn't registered — caller should
+        fall back to the i18n template chain.
+
+        Cached per (action, locale) for the lifetime of the parser.
+        First call ~300-500ms, subsequent calls instant.
+        """
+        cached = self._feedback_cache.get(("confirm", action_name, locale))
+        if cached is not None:
+            return cached
+
+        action = get_action(action_name)
+        if action is None:
+            return None
+
+        prompt = (
+            "You are Korder, a voice assistant. The user just asked you "
+            "to perform an action that is irreversible or disruptive — "
+            "you must confirm before running it.\n\n"
+            f"Action description: {action.description}\n\n"
+            f"Locale: {locale} ({'Polish' if locale == 'pl' else 'English'})\n\n"
+            "Generate a brief confirmation question (max 12 words) in the "
+            "user's locale. Phrase it naturally and clearly — make it "
+            "obvious what is about to happen. End with a hint that the "
+            "user should say 'yes' or 'no' (or the locale equivalent).\n\n"
+            "Output ONLY the question, no explanation, no quotes, no prefix."
+        )
+        text = self._call_ollama_completion(prompt, max_tokens=40)
+        if not text:
+            return None
+        # Trim quotes/punctuation noise the model sometimes adds.
+        text = text.strip().strip('"').strip("'").strip()
+        if not text:
+            return None
+        self._feedback_cache[("confirm", action_name, locale)] = text
+        print(
+            f"[korder] feedback: confirm/{action_name}/{locale} → {text!r}",
+            flush=True, file=sys.stderr,
+        )
+        return text
+
+    def _call_ollama_completion(self, prompt: str, max_tokens: int = 80) -> str | None:
+        """Free-form text completion (no JSON mode, no structured
+        output). Used for generating user-facing strings on the fly.
+        Returns None on any error so callers can fall back gracefully.
+
+        ``think: false`` is critical: gemma4 is a thinking-capable
+        model and defaults to emitting reasoning tokens before the
+        actual answer. With our short num_predict budget, the
+        response field comes back empty (whole budget eaten by
+        thinking tokens that go to a separate field). Setting
+        ``think: false`` bypasses the reasoning step and writes
+        directly to the response field.
+        """
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "think": False,
+            "keep_alive": self.keep_alive_s,
+            "options": {
+                "temperature": 0.3,
+                "num_predict": max_tokens,
+            },
+        }
+        try:
+            req = urllib.request.Request(
+                _OLLAMA_URL,
+                data=json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            print(f"[korder] feedback completion failed: {e}", flush=True, file=sys.stderr)
+            return None
+        return (body.get("response") or "").strip() or None
 
     def parse(self, transcript: str) -> list[tuple]:
         if not transcript:

--- a/src/korder/ui/i18n.py
+++ b/src/korder/ui/i18n.py
@@ -158,9 +158,17 @@ _STRINGS: dict[str, dict[str, str]] = {
 }
 
 
+def current_locale() -> str:
+    """Best-guess two-letter locale tag for the running session.
+    Returns the prefix of QLocale.system().name() (e.g., 'pl' for
+    'pl_PL', 'en' for 'en_US'). Used by callers that need to feed
+    locale to non-i18n consumers (e.g. an LLM generating user-facing
+    text)."""
+    return QLocale.system().name().split("_")[0].lower() or "en"
+
+
 def _bundle() -> dict[str, str]:
-    lang = QLocale.system().name().split("_")[0].lower()
-    return _STRINGS.get(lang) or _STRINGS["en"]
+    return _STRINGS.get(current_locale()) or _STRINGS["en"]
 
 
 def t(key: str) -> str:

--- a/src/korder/ui/main_window.py
+++ b/src/korder/ui/main_window.py
@@ -26,7 +26,7 @@ from korder.audio.vad import SpeechDetector
 from korder.transcribe.whisper_engine import WhisperEngine
 from korder.inject import YdotoolBackend, InjectError
 from korder.ui.osd import OSDWindow
-from korder.ui.i18n import t
+from korder.ui.i18n import current_locale, t
 from korder.ui.progress import progress_signal
 
 
@@ -176,6 +176,7 @@ class MainWindow(QMainWindow):
         ducker: VolumeDucker | None = None,
         wake_detector=None,
         wake_idle_timeout_s: float = 5.0,
+        confirm_prompt_generator=None,
     ):
         super().__init__()
         self.setWindowTitle("Korder — transcript history")
@@ -194,6 +195,14 @@ class MainWindow(QMainWindow):
         # Wake-word activation (issue #1). Optional — None means hotkey-only.
         self._wake_detector = wake_detector
         self._wake_idle_timeout_s = float(wake_idle_timeout_s)
+        # Optional callable: (action_name, locale) -> str | None.
+        # When set, the pending-prompt resolver consults it before
+        # falling back to the i18n template chain. The actual
+        # generator is IntentParser.generate_confirm_prompt, which
+        # caches results so the call is instant after the first time
+        # (or after the warm_feedback_cache pre-generation finishes
+        # in the background at startup).
+        self._confirm_prompt_generator = confirm_prompt_generator
         # True for the dictation session that began via a wake event.
         # Resets to False on every dictation end. Used to gate the
         # idle-timeout timer that returns accidental wakes to wake-mode.
@@ -878,22 +887,43 @@ class MainWindow(QMainWindow):
         if action and action.parameters:
             param_label = next(iter(action.parameters.keys()))
         prompt_so_far = self._osd._state.prompt or action_name
-        # Hint resolution: try action-specific pending prompt first
-        # (e.g. "Shut down the computer? say 'yes'" for shutdown), then
-        # per-parameter prompt ("say the query…" for spotify_search),
-        # then generic ("say the parameter…"). i18n's t() returns the
-        # key itself when no translation exists, so a key-equals-result
-        # comparison detects the miss.
-        action_key = f"pending_prompt_{action_name}"
-        action_hint = t(action_key)
-        if action_hint != action_key:
-            hint = action_hint
-        elif param_label:
-            specific_key = f"say_the_param_{param_label}"
-            specific = t(specific_key)
-            hint = specific if specific != specific_key else t("pending_param_hint")
-        else:
-            hint = t("pending_param_hint")
+        # Hint resolution chain, highest-priority first:
+        #   1. LLM-generated confirmation prompt — when the action is
+        #      destructive (has a 'confirm' parameter) and the
+        #      generator is wired, ask Gemma for a contextual phrase
+        #      in the current locale. Cached, so this is instant after
+        #      warm_feedback_cache populates at startup.
+        #   2. Action-specific pending_prompt_<name> i18n key — static
+        #      hand-written fallback for when the LLM is unavailable
+        #      or off.
+        #   3. Per-parameter say_the_param_<label> — generic param
+        #      extraction (Spotify search, etc.).
+        #   4. The bare pending_param_hint — last-resort placeholder.
+        # i18n's t() returns the key itself on miss, so a
+        # key-equals-result comparison detects the fall-through.
+        hint: str | None = None
+        if self._confirm_prompt_generator is not None and "confirm" in (
+            (action.parameters if action else {}) or {}
+        ):
+            try:
+                hint = self._confirm_prompt_generator(action_name, current_locale())
+            except Exception as e:
+                print(
+                    f"[korder] confirm prompt generation failed: {e}",
+                    flush=True, file=sys.stderr,
+                )
+                hint = None
+        if not hint:
+            action_key = f"pending_prompt_{action_name}"
+            action_hint = t(action_key)
+            if action_hint != action_key:
+                hint = action_hint
+            elif param_label:
+                specific_key = f"say_the_param_{param_label}"
+                specific = t(specific_key)
+                hint = specific if specific != specific_key else t("pending_param_hint")
+            else:
+                hint = t("pending_param_hint")
         self._osd.set_pending(prompt_so_far, hint)
         self.statusBar().showMessage(
             f"Pending: {action_name} waiting for parameter",

--- a/tests/test_intent_feedback.py
+++ b/tests/test_intent_feedback.py
@@ -1,0 +1,115 @@
+"""Tests for IntentParser's LLM-generated feedback layer — the
+generate_confirm_prompt path that produces natural-language
+confirmation questions for destructive actions, with caching and
+graceful failure handling."""
+from __future__ import annotations
+
+import korder.actions  # noqa: F401  (default registrations)
+from korder.intent import IntentParser
+
+
+def _parser_with_completion(completion_returns):
+    """Build a parser whose _call_ollama_completion is patched to return
+    the given values per call (callable for dynamic, str for fixed,
+    list for sequential)."""
+    p = IntentParser()
+    if callable(completion_returns):
+        p._call_ollama_completion = completion_returns
+    elif isinstance(completion_returns, list):
+        seq = iter(completion_returns)
+        p._call_ollama_completion = lambda *_a, **_kw: next(seq, None)
+    else:
+        p._call_ollama_completion = lambda *_a, **_kw: completion_returns
+    return p
+
+
+def test_generate_confirm_prompt_returns_completion_text():
+    parser = _parser_with_completion("Are you sure you want to shut down?")
+    text = parser.generate_confirm_prompt("shutdown", locale="en")
+    assert text == "Are you sure you want to shut down?"
+
+
+def test_generate_confirm_prompt_caches_per_action_and_locale():
+    calls = []
+    def fake(prompt, max_tokens=80):
+        calls.append((prompt, max_tokens))
+        return "cached question?"
+    parser = _parser_with_completion(fake)
+
+    parser.generate_confirm_prompt("shutdown", locale="en")
+    parser.generate_confirm_prompt("shutdown", locale="en")
+    parser.generate_confirm_prompt("shutdown", locale="en")
+    assert len(calls) == 1, "expected single completion call across three lookups"
+
+    # Different locale → fresh call.
+    parser.generate_confirm_prompt("shutdown", locale="pl")
+    assert len(calls) == 2
+
+    # Different action → fresh call.
+    parser.generate_confirm_prompt("reboot", locale="en")
+    assert len(calls) == 3
+
+
+def test_generate_confirm_prompt_returns_none_for_unknown_action():
+    parser = _parser_with_completion("should not be returned")
+    assert parser.generate_confirm_prompt("does_not_exist", locale="en") is None
+
+
+def test_generate_confirm_prompt_returns_none_when_completion_fails():
+    """LLM call returned None (transient ollama hiccup) — caller falls
+    back to the i18n template chain."""
+    parser = _parser_with_completion(None)
+    assert parser.generate_confirm_prompt("shutdown", locale="en") is None
+    # Failed result is NOT cached — next call retries.
+    calls = []
+    parser._call_ollama_completion = lambda *a, **kw: calls.append(1) or None
+    parser.generate_confirm_prompt("shutdown", locale="en")
+    assert len(calls) == 1
+
+
+def test_generate_confirm_prompt_strips_quotes_and_whitespace():
+    """Models sometimes wrap the answer in quotes — strip them so the
+    OSD doesn't render literal quote marks."""
+    parser = _parser_with_completion('  "Confirm shutdown?"  ')
+    assert parser.generate_confirm_prompt("shutdown", locale="en") == "Confirm shutdown?"
+
+
+def test_generate_confirm_prompt_passes_action_description_to_completion():
+    """The prompt sent to the LLM must include the action's description
+    so the model knows what's being confirmed."""
+    received_prompts = []
+    def capture(prompt, max_tokens=80):
+        received_prompts.append(prompt)
+        return "ok?"
+    parser = _parser_with_completion(capture)
+    parser.generate_confirm_prompt("shutdown", locale="en")
+    assert received_prompts, "completion was not called"
+    sent = received_prompts[0]
+    # The shutdown action's description starts with "Power off the computer."
+    assert "Power off the computer" in sent
+    # Locale info should be present so the model picks the right language.
+    assert "en" in sent.lower() or "english" in sent.lower()
+
+
+def test_warm_feedback_cache_skips_already_cached():
+    """Pre-generation should not redo work for entries already in the
+    cache (e.g. populated by an earlier explicit generate call)."""
+    calls = []
+    def fake(prompt, max_tokens=80):
+        calls.append(1)
+        return "fresh prompt?"
+    parser = _parser_with_completion(fake)
+    # Pre-populate one entry.
+    parser._feedback_cache[("confirm", "shutdown", "en")] = "already there"
+
+    # warm_feedback_cache is async (daemon thread); join for the test.
+    import threading
+    pre_threads = {t.ident for t in threading.enumerate()}
+    parser.warm_feedback_cache(locale="en")
+    new_threads = [t for t in threading.enumerate() if t.ident not in pre_threads]
+    for t in new_threads:
+        t.join(timeout=2.0)
+
+    # Pre-existing cache entry preserved; reboot and sleep generated fresh.
+    assert parser._feedback_cache[("confirm", "shutdown", "en")] == "already there"
+    assert len(calls) == 2, f"expected exactly 2 fresh completions, got {len(calls)}"


### PR DESCRIPTION
First step toward LLM-generated user-facing feedback (per the user's refactor request). Scoped tightly to **confirmation prompts only** because they're low-frequency, high-value, and already gated behind a "wait" state where ~300 ms of LLM round-trip is invisible.

## Summary

When a user says *"shutdown computer"* and we transition to pending, the OSD's trailing chip used to read a hand-written i18n template like *"Wyłączyć komputer? powiedz 'tak'"*. Now Gemma writes the prompt itself, using the action's existing description as the seed. Real output from \`gemma4:e2b\` on this machine:

| Action | Locale | Generated prompt |
|---|---|---|
| shutdown | en | "Are you sure you want to power off the computer?" |
| shutdown | pl | "Czy chcesz wyłączyć komputer? Powiedz tak lub nie." |
| reboot | en | "Are you sure you want to restart the computer?" |
| reboot | pl | "Czy chcesz zrestartować komputer? Powiedz tak lub nie." |
| sleep | en | "Do you want to suspend the computer now?" |
| sleep | pl | "Czy chcesz uśpienie komputera? Powiedz tak lub nie." |

(The Polish for sleep is grammatically awkward — "uśpienie" is nominalized; gemma4:e4b would likely do better.)

## Pipeline

\`\`\`
Action.description ──→ IntentParser.generate_confirm_prompt
                                ↓
                       _call_ollama_completion
                       (think:false, num_predict:80, t=0.3)
                                ↓
                       cache[(action, locale)] = text
                                ↓
                       _on_pending_action reads cache first,
                       falls back to pending_prompt_<name>
                       i18n key, then per-param, then generic.
\`\`\`

\`Action.description\` is already the source of truth used by the parser to recognize the action. Pointing the generation prompt at it means a single edit to the description updates both how the model parses AND how it phrases the confirmation.

## Performance

- **Cache hit**: instant (the common path).
- **Cache miss**: ~300-500 ms LLM round-trip on the main thread.
- **Pre-generation**: \`warm_feedback_cache(locale)\` runs at app boot in a daemon thread, walks all confirmable actions, and populates the cache before the user can possibly trigger one. By the time a real "shutdown" comes in, the prompt is already there.

## Why \`think: false\`

Gemma4 is a thinking-capable model that defaults to emitting reasoning tokens before the answer. With our 80-token budget for short prompts, the entire budget was getting consumed by silent thinking — the \`response\` field came back empty with \`done_reason:"length"\`. \`think: false\` bypasses the reasoning step and writes directly to the response field. (Spent some time isolating this — worth knowing for any future LLM-generation path.)

## Fallback chain

In \`_on_pending_action\`:

1. **LLM-generated** (this PR) — when \`confirm_prompt_generator\` is wired AND the action has a "confirm" parameter.
2. \`pending_prompt_<action_name>\` i18n key — hand-written per-action override (already in the codebase from the previous power-actions PR).
3. \`say_the_param_<param_label>\` i18n key — per-parameter prompt for non-confirmation params (Spotify search query, etc.).
4. Generic \`pending_param_hint\` — last-resort placeholder.

Each tier degrades cleanly: if Gemma is offline, we get hand-written prompts; if those don't exist, we get per-param hints; if those don't exist, generic.

## Test plan

- [x] 7 new unit tests in \`tests/test_intent_feedback.py\` covering cache dimensions, missing-action returns None, failed-completion not cached (retryable), quote stripping, action-description-in-prompt, and \`warm_feedback_cache\` skipping pre-populated entries.
- [x] All 215 tests pass (1 unrelated e2b "Odtwórz" flake).
- [x] Manual: real ollama with gemma4:e2b generated the six prompts in the table above end-to-end.

## Why scope to confirmation prompts only

Initial prompt was "confirmation text and other similar feedback texts." Confirmation is the right first place to land this:

- **Low frequency**: fires once per dangerous action. Round-trip latency is invisible.
- **High value**: the natural language reads better than rigid templates, and the LLM adapts to the action's actual semantics rather than a static "say yes to confirm."
- **Already on a wait state**: the user is in pending listening for their confirmation; an extra 300 ms of OSD update delay is not noticed.

Progress narration (\`progress_searching\`, \`progress_found\`, etc.) is **out of scope** — those fire repeatedly on hot paths and the latency stack would matter. If/when we want LLM-generated progress, that's a separate PR with batched/cached/async semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)