### PR TITLE
feat: conversational queries — answer questions with no action match

### DIFF
--- a/src/korder/intent.py
+++ b/src/korder/intent.py
@@ -87,15 +87,21 @@ _SYSTEM_PROMPT = (
     "- For parameterized actions, extract relevant fields into `params`. If a required parameter "
     "is not present in the input, leave `params` empty or omit it — do NOT invent values.\n"
     "\n"
-    "Optionally include `response` — a brief natural-language question — "
-    "ONLY when the action has parameters that the user did not supply. "
-    "Tailor the question to which parameter is missing:\n"
-    "  - For a `confirm` parameter: 'are you sure?' style — make it obvious "
-    "what is about to happen and ask for yes/no.\n"
-    "  - For other parameters (`query`, `kind`, etc.): ask WHAT the user "
-    "wants — e.g. 'What do you want to play?' for a search query.\n"
-    "Write `response` in the same language as the input transcript. "
-    "Otherwise omit `response` (most non-pending commands fire silently)."
+    "Optionally include `response` — a brief natural-language reply to the "
+    "user. Three cases where `response` should be populated:\n"
+    "  - Action has a `confirm` parameter the user did not supply: ask "
+    "'are you sure?' in second person, end with yes/no hint.\n"
+    "  - Action has another missing parameter (`query`, `kind`, etc.): ask "
+    "WHAT the user wants — e.g. 'What do you want to play?'.\n"
+    "  - Conversational query (no action match) with a clear factual "
+    "answer YOU know from your training — math, definitions, "
+    "translations, general knowledge, geography, history. Write the "
+    "answer directly. Do NOT answer questions about live data (current "
+    "time, today's weather, news) — leave `response` empty for those, "
+    "you'll only hallucinate.\n"
+    "Always write `response` in the same language as the input transcript. "
+    "For pure dictation (description, narrative, prose with no question "
+    "and no command), leave `response` empty."
 )
 
 
@@ -135,6 +141,9 @@ def _build_user_prompt(transcript: str, *, show_triggers: bool) -> str:
         '  "shutdown computer yes" → {"actions": [{"phrase": "shutdown computer yes", "name": "shutdown", "params": {"confirm": "yes"}}]}\n'
         '  "Spotify zagraj" → {"actions": [{"phrase": "Spotify zagraj", "name": "spotify_search"}], "response": "Co chcesz odtworzyć w Spotify?"}\n'
         '  "play on Spotify" → {"actions": [{"phrase": "play on Spotify", "name": "spotify_search"}], "response": "What do you want to play on Spotify?"}\n'
+        '  "what is the capital of France" → {"actions": [], "response": "Paris."}\n'
+        '  "ile to siedem razy osiem" → {"actions": [], "response": "Pięćdziesiąt sześć."}\n'
+        '  "what time is it" → {"actions": []}    (live data — no response, model would hallucinate)\n'
         "\n"
         f"Now analyze this transcript and return ONLY the JSON object:\n"
         f"Input: {json.dumps(transcript, ensure_ascii=False)}\n"
@@ -266,7 +275,15 @@ class IntentParser:
         # mode toggles in particular). LLM still wins for "she pressed
         # enter on the keyboard" because regex would also classify that
         # as text-only thanks to the word-boundary trigger phrasing.
+        #
+        # Exception: when last_response is populated, the LLM intentionally
+        # chose to answer the user conversationally rather than dispatch
+        # an action. Skipping the regex supplement preserves that choice
+        # — otherwise a fuzzy trigger match like "what is" → wikipedia
+        # would overshadow Gemma's direct answer.
         if not actions:
+            if self.last_response:
+                return [("text", transcript)] if transcript else []
             regex_ops = split_into_ops(transcript)
             if any(op[0] != "text" for op in regex_ops):
                 print(

--- a/src/korder/ui/main_window.py
+++ b/src/korder/ui/main_window.py
@@ -775,6 +775,23 @@ class MainWindow(QMainWindow):
                 QTimer.singleShot(150, self._auto_stop)
             return
 
+        # Conversational-answer path: the user asked a question with no
+        # registered action match, and Gemma populated `response` with
+        # a free-form reply (math, definitions, translation, general
+        # knowledge). Show the answer in the OSD instead of falling
+        # through to the "didn't get that" reset, then transition back
+        # to listening so the user can ask a follow-up.
+        if (
+            not command_fired
+            and self._pending_action is None
+            and self._last_llm_response
+            and self._recorder.is_recording
+        ):
+            answer = self._last_llm_response
+            self._last_llm_response = ""
+            QTimer.singleShot(120, lambda a=answer: self._show_conversational_answer(a))
+            return
+
         # Pure-dictation path: the LLM produced no command actions this
         # round (or auto-stop is off). If the recorder is still open and
         # there's no pending parameter expected, give the user a fresh
@@ -789,6 +806,45 @@ class MainWindow(QMainWindow):
             and self._recorder.is_recording
         ):
             QTimer.singleShot(700, self._reset_to_listening_after_miss)
+
+    def _show_conversational_answer(self, answer: str) -> None:
+        """Display Gemma's free-form reply for a no-action conversational
+        query (math, definition, translation, general knowledge).
+        Reuses the executing-progress visual treatment — italic, accent
+        color — so the answer reads as system feedback distinct from
+        the user's own dictated text. After a read window proportional
+        to the answer's length, transition back to listening so the
+        user can ask a follow-up. No-op if the recorder closed or
+        another state took over in the interim."""
+        if not self._recorder.is_recording:
+            return
+        if self._pending_action is not None:
+            return
+        print(f"[korder] conversational answer: {answer!r}", flush=True)
+        self._osd.set_executing_progress(answer)
+        # Read window: ~50 ms per character + 1.5 s minimum + 7 s
+        # ceiling. Long enough for Polish multi-clause sentences, short
+        # enough that an absent user doesn't sit on a stale answer.
+        read_ms = max(1500, min(7000, 1500 + 50 * len(answer)))
+        QTimer.singleShot(read_ms, self._reset_to_listening_after_answer)
+
+    def _reset_to_listening_after_answer(self) -> None:
+        """Mirror of _reset_to_listening_after_miss but for the path
+        where a conversational answer was just displayed. Same
+        end-state — fresh listening with placeholder — but expects to
+        be called from 'executing' rather than 'committed'."""
+        if not self._recorder.is_recording:
+            return
+        if self._pending_action is not None:
+            return
+        if self._osd._state.stateKind != "executing":
+            return  # user started a new utterance — let that flow win
+        # Skip past any audio captured while the user was reading.
+        self._committed_samples = self._recorder.snapshot().shape[0]
+        self._reset_partial_render_state()
+        self._last_partial_norm = ""
+        self._stability_count = 0
+        self._osd.set_listening(write_mode=self._write_mode)
 
     def _reset_to_listening_after_miss(self) -> None:
         """Transition from 'committed' to a fresh 'listening' with a

--- a/tests/test_intent_response.py
+++ b/tests/test_intent_response.py
@@ -144,6 +144,25 @@ def test_legitimate_confirm_param_passes_through():
     assert "callable" in kinds, f"expected the action to fire; got {ops!r}"
 
 
+def test_last_response_for_conversational_no_action_query():
+    """Pure-conversational queries — no action match but the LLM has
+    a factual answer — populate `response` and produce no ops besides
+    the original text. main_window's _show_conversational_answer
+    consumer detects this case (actions empty + last_response set)
+    and renders the reply in the OSD instead of the 'didn't get
+    that' reset."""
+    p, mock_urlopen = _patched_parser({
+        "actions": [],
+        "response": "Paris.",
+    })
+    with mock_urlopen:
+        ops = p.parse("what is the capital of France")
+    assert p.last_response == "Paris."
+    # Empty actions → text op for the original transcript (regex
+    # supplement runs but won't match either, so just the text).
+    assert ("text", "what is the capital of France") in ops
+
+
 def test_last_response_strips_whitespace():
     """Models sometimes wrap with leading/trailing whitespace —
     consumers display this directly so leading newlines look bad."""


### PR DESCRIPTION
First consumer of the \`response\` field beyond pending-prompt confirmations. When the user asks a question with a clear factual answer that Gemma knows from training (math, definitions, translations, geography, history), Korder now displays the answer in the OSD instead of falling through to "I didn't get that."

Real E4B output:

| Input | Output |
|---|---|
| *"what is the capital of France"* | response: *"Paris."* |
| *"ile to siedem razy osiem"* | response: *"Pięćdziesiąt sześć."* |
| *"jak powiedzieć dziękuję po hiszpańsku"* | response: *"…To 'gracias'."* |
| *"what time is it"* | response: *""* (live data — empty by design) |
| *"hello world this is dictation"* | response: *""* (pure dictation) |
| *"press enter"* | response: *""* (action, no missing params) |

## Pipeline

\`\`\`
Whisper text → IntentParser.parse() → _call_ollama (format=json)
                                       └─ {"actions":[], "response":"Paris."}
                                       └─ self.last_response = "Paris."
              → ops: [("text", "what is the capital of France")]
              (regex supplement skipped because response is populated —
               otherwise "what is" would match wikipedia_search)
→ Worker emits parse_response("Paris.")
→ MainWindow stores on _last_llm_response
→ _on_inject_done: no command + no pending + response set
                   → _show_conversational_answer("Paris.")
                       → osd.set_executing_progress("Paris.")  italic accent
                       → schedule _reset_to_listening_after_answer
                         (read window ~50ms/char, 1.5s–7s clamped)
                       → fresh listening for follow-up
\`\`\`

## What this PR does

1. **System prompt grows a third \`response\` case**: alongside the existing confirm-prompt and missing-parameter cases, Gemma is now told to answer conversational queries with clear factual responses, AND told to leave \`response\` empty for live-data queries (current time, weather) where it would only hallucinate.

2. **Three new examples** in the user prompt anchor the conversational shape — English geography, Polish math, and the negative *"what time is it"* case so the model learns the boundary.

3. **\`parse()\` skips the regex supplement when \`last_response\` is populated.** Without this, *"what is the capital of France"* would have its empty-actions overridden by a wikipedia_search fuzzy match (because "what is" is a wikipedia trigger) and the conversational answer would never surface. The check trusts the LLM's intentional empty-actions choice.

4. **MainWindow's \`_on_inject_done\`** detects the conversational case (no command, no pending, response present) and calls a new \`_show_conversational_answer\`. The answer renders via \`set_executing_progress\` (italic accent — same visual as Spotify progress narration), then a length-aware read window transitions back to listening via a new \`_reset_to_listening_after_answer\` helper.

## Wake-mode + hotkey-mode interaction

- **Wake mode**: recorder stays open after the answer; the existing wake-idle-timeout returns to wake-listening if the user doesn't follow up within 5 s.
- **Hotkey mode**: recorder stays open; user closes via toggle/cancel as today.

## Test plan

- [x] All 218 tests pass (1 new test for the conversational path: no-action utterance with populated response → text op + last_response set).
- [x] \`intent_bench --model gemma4:e4b\` → 20/21 (same \`ciszej\` run-to-run flake, no regression).
- [x] Manual E4B with 6 inputs covering all three response cases (action+confirm, action+missing-param, conversational, live-data, dictation, plain action).
- [x] Skip-regex-supplement verified with *"what is the capital of France"* — the \`what is\` wikipedia trigger no longer hijacks the conversational answer.

## Future expansion (not in this PR)

- TTS (issue #2) — same data, just adds Piper/spd-say synthesis. The \`response\` field is what gets spoken.
- Multi-turn dialogue — pass a few prior turns into the parser's context so follow-ups can reference earlier answers.
- Tool-use for live data — let the LLM call a "get_time" subroutine when the user asks the time, instead of leaving response empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)