### PR TITLE
Per-session conversation history + chattier responses + graceful end

### DIFF
--- a/src/korder/actions/system.py
+++ b/src/korder/actions/system.py
@@ -264,15 +264,19 @@ register(_confirmable_action(
 register(Action(
     name="cancel_session",
     description=(
-        "Abort the current dictation/recording. Drops any pending text "
-        "AND any other actions in the same utterance — nothing gets "
-        "injected, the OSD shows 'Cancelled' and hides, the mic closes. "
-        "Use ONLY when the user is plainly aborting the recording: "
-        "saying just 'cancel', 'nevermind', 'forget it', or similar as "
-        "the entire intent. Do NOT fire when 'cancel' / 'nevermind' "
-        "appear inside dictated content (e.g., 'I want to cancel my "
-        "subscription' is dictation, not a meta-cancel). When in doubt, "
-        "treat it as text — a misfire here loses the user's whole "
+        "End the current dictation/recording session. Drops any pending "
+        "text AND any other actions in the same utterance — nothing "
+        "gets injected, the OSD hides, the mic closes. Two flavors of "
+        "intent map to this: (a) ABORT — 'cancel that', 'nevermind', "
+        "'forget it', 'nieważne'; and (b) GRACEFUL END — 'that's all', "
+        "'we're done', 'I'm done', 'thanks, that's it', 'koniec', "
+        "'zakończ', 'to wszystko', 'to tyle', 'wystarczy'. Both close "
+        "the session the same way. Use ONLY when the user's whole "
+        "utterance is a meta-end signal — closing remark addressed to "
+        "the assistant, not dictated content. Do NOT fire when these "
+        "phrases appear inside content (e.g. 'I want to cancel my "
+        "subscription' is dictation, not a meta-cancel). When in "
+        "doubt, treat it as text — a misfire here drops the whole "
         "utterance and is more disruptive than typing the word."
     ),
     triggers={
@@ -282,12 +286,29 @@ register(Action(
             "never mind",
             "forget it",
             "abort recording",
+            "that's all",
+            "thats all",
+            "we're done",
+            "were done",
+            "we are done",
+            "i'm done",
+            "im done",
+            "i am done",
+            "stop listening",
+            "end session",
         ],
         "pl": [
             "nieważne",
             "nie ważne",
             "zapomnij",
             "anuluj nagrywanie",
+            "koniec",
+            "zakończ",
+            "zakończę",
+            "to wszystko",
+            "to tyle",
+            "wystarczy",
+            "skończ",
         ],
     },
     op_factory=lambda _args: ("cancel", None),

--- a/src/korder/actions/web.py
+++ b/src/korder/actions/web.py
@@ -163,12 +163,14 @@ def _maps_search_op(args: dict) -> tuple | None:
 register(Action(
     name="web_search",
     description=(
-        "Open the user's default browser with a generic web search. Use "
-        "for general 'search the web for X', 'google X', 'look up X' "
-        "where the user wants regular search results. Do NOT use for "
-        "queries that explicitly say YouTube, Wikipedia, or Maps — those "
-        "have their own actions. Extract the actual search terms into "
-        "params.query without including the trigger word itself."
+        "Open the user's default browser on a generic web-search results "
+        "page. Use ONLY when the user explicitly asks to SEARCH the web — "
+        "phrasings like 'search the web for X', 'google X', 'wyszukaj w "
+        "internecie X'. Do NOT use for general factual questions ('what "
+        "is X', 'co to jest X', 'how tall is X') — answer those directly "
+        "via the response field instead. Only dispatch when the user "
+        "wants the browser opened on results. Extract the actual search "
+        "terms into params.query without the trigger word."
     ),
     triggers={
         "en": [
@@ -234,12 +236,15 @@ register(Action(
 register(Action(
     name="wikipedia_search",
     description=(
-        "Open Wikipedia for a topic. Use when the user wants to look up / "
-        "read about / find information on a specific subject — typical "
-        "phrasings: 'wikipedia X', 'co to jest X', 'kim był X', 'tell me "
-        "about X', 'read about X'. Picks the Wikipedia language matching "
-        "the system locale automatically. Extract the actual subject "
-        "into params.query."
+        "Open Wikipedia in the user's browser for a topic. Use ONLY when "
+        "the user explicitly names Wikipedia or asks to LOOK SOMETHING "
+        "UP on it — 'wikipedia X', 'look up X on Wikipedia', 'open the "
+        "Wikipedia article for X'. Do NOT use for general 'what is X', "
+        "'co to jest X', 'tell me about X', 'kim był X' — those are "
+        "conversational and should be answered directly via the response "
+        "field. Only dispatch when the user wants the article OPENED in "
+        "a browser. Picks the Wikipedia language matching the system "
+        "locale. Extract the subject into params.query."
     ),
     triggers={
         "en": [

--- a/src/korder/app.py
+++ b/src/korder/app.py
@@ -159,6 +159,7 @@ def _run_app() -> int:
     op_parser_is_warm = None
     op_parser_warm_up = None
     op_parser_last_response = None
+    op_parser_clear_history = None
     if cfg["inject"]["action_parser"].lower() == "llm":
         from korder.intent import IntentParser
         thinking = _bool(cfg["intent"]["thinking_mode"])
@@ -186,6 +187,10 @@ def _run_app() -> int:
         # actions; replaces PR #6's separate-call generation +
         # boot-time cache warming.
         op_parser_last_response = lambda: intent_parser.last_response
+        # Drop conversation history at session boundaries (mic close /
+        # cancel). Scopes follow-up resolution to a single dictation
+        # invocation — see IntentParser.clear_history.
+        op_parser_clear_history = intent_parser.clear_history
         flags = []
         if thinking:
             flags.append("thinking")
@@ -204,6 +209,7 @@ def _run_app() -> int:
             op_parser_is_warm=op_parser_is_warm,
             op_parser_warm_up=op_parser_warm_up,
             op_parser_last_response=op_parser_last_response,
+            op_parser_clear_history=op_parser_clear_history,
         )
     except InjectError as e:
         print(f"[korder] injection disabled: {e}", file=sys.stderr)

--- a/src/korder/inject.py
+++ b/src/korder/inject.py
@@ -60,6 +60,7 @@ class YdotoolBackend:
         op_parser_is_warm=None,
         op_parser_warm_up=None,
         op_parser_last_response=None,
+        op_parser_clear_history=None,
     ):
         if shutil.which("ydotool") is None:
             raise InjectError(
@@ -76,6 +77,12 @@ class YdotoolBackend:
         # Used for confirmation prompts today; future home for
         # conversational replies and TTS-spoken progress.
         self._op_parser_last_response = op_parser_last_response
+        # Optional callable -> None. Called by the UI on dictation-
+        # session boundaries (recorder stop, cancel) to drop the
+        # parser's conversation history so the next session starts
+        # fresh — cross-session follow-up resolution would be more
+        # confusing than helpful.
+        self._op_parser_clear_history = op_parser_clear_history
         self._lock = threading.Lock()
         self.is_slow_parser = op_parser is not None
 
@@ -100,6 +107,19 @@ class YdotoolBackend:
             return
         try:
             self._op_parser_warm_up()
+        except Exception:
+            pass
+
+    def clear_op_parser_history(self) -> None:
+        """End the current dictation session's conversation context. The
+        UI calls this from _stop_recording so the next session — fresh
+        wake-word fire or hotkey toggle — starts without yesterday's
+        Q&A leaking into resolution. No-op for parsers without history
+        (regex)."""
+        if self._op_parser_clear_history is None:
+            return
+        try:
+            self._op_parser_clear_history()
         except Exception:
             pass
 
@@ -288,6 +308,7 @@ def make_backend(
     op_parser_is_warm=None,
     op_parser_warm_up=None,
     op_parser_last_response=None,
+    op_parser_clear_history=None,
 ) -> YdotoolBackend:
     return YdotoolBackend(
         paste_mode=paste_mode,
@@ -295,4 +316,5 @@ def make_backend(
         op_parser_is_warm=op_parser_is_warm,
         op_parser_warm_up=op_parser_warm_up,
         op_parser_last_response=op_parser_last_response,
+        op_parser_clear_history=op_parser_clear_history,
     )

--- a/src/korder/intent.py
+++ b/src/korder/intent.py
@@ -87,15 +87,21 @@ _SYSTEM_PROMPT = (
     "- For parameterized actions, extract relevant fields into `params`. If a required parameter "
     "is not present in the input, leave `params` empty or omit it — do NOT invent values.\n"
     "\n"
-    "Optionally include `response` — a brief natural-language question — "
-    "ONLY when the action has parameters that the user did not supply. "
-    "Tailor the question to which parameter is missing:\n"
-    "  - For a `confirm` parameter: 'are you sure?' style — make it obvious "
-    "what is about to happen and ask for yes/no.\n"
-    "  - For other parameters (`query`, `kind`, etc.): ask WHAT the user "
-    "wants — e.g. 'What do you want to play?' for a search query.\n"
-    "Write `response` in the same language as the input transcript. "
-    "Otherwise omit `response` (most non-pending commands fire silently)."
+    "Optionally include `response` — a brief natural-language reply to the "
+    "user. Three cases where `response` should be populated:\n"
+    "  - Action has a `confirm` parameter the user did not supply: ask "
+    "'are you sure?' in second person, end with yes/no hint.\n"
+    "  - Action has another missing parameter (`query`, `kind`, etc.): ask "
+    "WHAT the user wants — e.g. 'What do you want to play?'.\n"
+    "  - Conversational query (no action match) with a clear factual "
+    "answer YOU know from your training — math, definitions, "
+    "translations, general knowledge, geography, history. Write the "
+    "answer directly. Do NOT answer questions about live data (current "
+    "time, today's weather, news) — leave `response` empty for those, "
+    "you'll only hallucinate.\n"
+    "Always write `response` in the same language as the input transcript. "
+    "For pure dictation (description, narrative, prose with no question "
+    "and no command), leave `response` empty."
 )
 
 
@@ -135,6 +141,9 @@ def _build_user_prompt(transcript: str, *, show_triggers: bool) -> str:
         '  "shutdown computer yes" → {"actions": [{"phrase": "shutdown computer yes", "name": "shutdown", "params": {"confirm": "yes"}}]}\n'
         '  "Spotify zagraj" → {"actions": [{"phrase": "Spotify zagraj", "name": "spotify_search"}], "response": "Co chcesz odtworzyć w Spotify?"}\n'
         '  "play on Spotify" → {"actions": [{"phrase": "play on Spotify", "name": "spotify_search"}], "response": "What do you want to play on Spotify?"}\n'
+        '  "what is the capital of France" → {"actions": [], "response": "Paris."}\n'
+        '  "ile to siedem razy osiem" → {"actions": [], "response": "Pięćdziesiąt sześć."}\n'
+        '  "what time is it" → {"actions": []}    (live data — no response, model would hallucinate)\n'
         "\n"
         f"Now analyze this transcript and return ONLY the JSON object:\n"
         f"Input: {json.dumps(transcript, ensure_ascii=False)}\n"
@@ -266,7 +275,15 @@ class IntentParser:
         # mode toggles in particular). LLM still wins for "she pressed
         # enter on the keyboard" because regex would also classify that
         # as text-only thanks to the word-boundary trigger phrasing.
+        #
+        # Exception: when last_response is populated, the LLM intentionally
+        # chose to answer the user conversationally rather than dispatch
+        # an action. Skipping the regex supplement preserves that choice
+        # — otherwise a fuzzy trigger match like "what is" → wikipedia
+        # would overshadow Gemma's direct answer.
         if not actions:
+            if self.last_response:
+                return [("text", transcript)] if transcript else []
             regex_ops = split_into_ops(transcript)
             if any(op[0] != "text" for op in regex_ops):
                 print(

--- a/src/korder/intent.py
+++ b/src/korder/intent.py
@@ -20,9 +20,28 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 
 from korder.actions.base import all_actions, get_action
 from korder.actions.parser import split_into_ops
+
+
+@dataclass(frozen=True)
+class Turn:
+    """One past exchange in the current dictation session: what the
+    user said, what action (if any) fired, and what natural-language
+    reply the LLM produced. Used as conversation context for
+    follow-up resolution — e.g. 'A Polski?' after asking about
+    France's capital."""
+    user_text: str
+    action_name: str  # main action name fired, "" if none
+    response: str  # last_response from that turn, "" if none
+
+
+# Number of past turns to feed into the parser as context. 4 covers
+# typical Q&A → follow-up → follow-up patterns without bloating the
+# prompt enough to risk a meaningful latency or accuracy regression.
+_MAX_HISTORY_TURNS = 4
 
 _OLLAMA_URL = "http://localhost:11434/api/generate"
 _OLLAMA_PS_URL = "http://localhost:11434/api/ps"
@@ -101,7 +120,13 @@ _SYSTEM_PROMPT = (
     "you'll only hallucinate.\n"
     "Always write `response` in the same language as the input transcript. "
     "For pure dictation (description, narrative, prose with no question "
-    "and no command), leave `response` empty."
+    "and no command), leave `response` empty.\n"
+    "\n"
+    "When previous turns are provided as context, USE them to resolve "
+    "follow-up questions like 'and Poland?' after 'what is the capital "
+    "of France?' — treat the new input as if its referring expressions "
+    "point at the prior turns. Don't repeat the entire prior question "
+    "back; just answer."
 )
 
 
@@ -122,14 +147,39 @@ def _render_action_catalogue(*, show_triggers: bool) -> str:
     return "\n".join(lines)
 
 
-def _build_user_prompt(transcript: str, *, show_triggers: bool) -> str:
-    """Per-call user message: action catalogue + transcript + reminder of
-    the JSON output format."""
+def _render_history(history: list[Turn]) -> str:
+    """Format prior turns as a 'Recent conversation' block to prepend to
+    the analysis section of the user prompt. Empty string when there's
+    no history. Each turn is one User: + Assistant: pair, trimmed of
+    empty fields so action-only turns don't print blank Assistant lines."""
+    if not history:
+        return ""
+    lines = ["Recent conversation in this session (oldest first):"]
+    for turn in history:
+        lines.append(f"  User: {turn.user_text!r}")
+        if turn.response:
+            lines.append(f"  Assistant: {turn.response!r}")
+        elif turn.action_name:
+            lines.append(f"  (Korder fired action: {turn.action_name})")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_user_prompt(
+    transcript: str,
+    history: list[Turn] | None = None,
+    *,
+    show_triggers: bool,
+) -> str:
+    """Per-call user message: action catalogue + optional conversation
+    history + transcript + reminder of the JSON output format."""
     catalogue = _render_action_catalogue(show_triggers=show_triggers)
+    history_block = _render_history(history or [])
     return (
         "Available actions:\n"
         f"{catalogue}\n"
         "\n"
+        + history_block +
         "A few examples to anchor your output shape:\n"
         '  "hello world" → {"actions": []}\n'
         '  "Naciśnij Enter." → {"actions": [{"phrase": "Naciśnij Enter", "name": "press_enter"}]}\n'
@@ -175,6 +225,12 @@ class IntentParser:
         # ground for future conversational/TTS features. Empty string
         # when the LLM didn't include a response (the common case).
         self.last_response: str = ""
+        # Rolling conversation history, fed back into the parser prompt
+        # so follow-up questions ('A Polski?' after the France-capital
+        # question) resolve against prior turns. Cleared by
+        # clear_history() on dictation-session boundaries
+        # (auto-stop, cancel, hotkey toggle-off).
+        self._history: list[Turn] = []
 
     def warm_up(self) -> None:
         """Fire-and-forget: tell ollama to page the model into VRAM,
@@ -247,6 +303,33 @@ class IntentParser:
                 return True
         return False
 
+    def clear_history(self) -> None:
+        """Drop the conversation context. Called by main_window at
+        dictation-session boundaries (recorder stops, cancel) so the
+        next session starts fresh — yesterday's 'and Polish?' shouldn't
+        resolve against last week's France question."""
+        if self._history:
+            print(f"[korder] history cleared ({len(self._history)} turns)", flush=True, file=sys.stderr)
+        self._history = []
+
+    def _push_turn(self, transcript: str, actions: list, response: str) -> None:
+        """Append a Turn for this parse to history, trimmed to the most
+        recent _MAX_HISTORY_TURNS entries. Action-only turns (no
+        response) still get recorded for context — 'press enter' →
+        'and now backspace?' should plausibly work."""
+        action_name = ""
+        if isinstance(actions, list) and actions:
+            first = actions[0]
+            if isinstance(first, dict):
+                action_name = first.get("name") or ""
+        self._history.append(Turn(
+            user_text=transcript,
+            action_name=action_name,
+            response=response,
+        ))
+        if len(self._history) > _MAX_HISTORY_TURNS:
+            self._history = self._history[-_MAX_HISTORY_TURNS:]
+
     def parse(self, transcript: str) -> list[tuple]:
         if not transcript:
             return []
@@ -255,6 +338,10 @@ class IntentParser:
         except Exception as e:
             print(f"[korder] intent LLM failed, falling back to regex: {e}", flush=True, file=sys.stderr)
             return split_into_ops(transcript)
+        # Record this turn BEFORE the regex-supplement / segmentation
+        # path forks — history is about what the LLM saw and produced,
+        # which is the input to the next round's resolution.
+        self._push_turn(transcript, actions, self.last_response)
 
         # Safety net: clear hallucinated `confirm` params. Smaller
         # models (e2b) sometimes invent a confirm value even when the
@@ -302,7 +389,9 @@ class IntentParser:
 
     def _call_ollama(self, transcript: str) -> list:
         user_prompt = _build_user_prompt(
-            transcript, show_triggers=self.show_triggers_in_prompt
+            transcript,
+            self._history,
+            show_triggers=self.show_triggers_in_prompt,
         )
         payload: dict = {
             "model": self.model,

--- a/src/korder/intent.py
+++ b/src/korder/intent.py
@@ -107,26 +107,47 @@ _SYSTEM_PROMPT = (
     "is not present in the input, leave `params` empty or omit it — do NOT invent values.\n"
     "\n"
     "Optionally include `response` — a brief natural-language reply to the "
-    "user. Three cases where `response` should be populated:\n"
+    "user. Cases where `response` should be populated:\n"
     "  - Action has a `confirm` parameter the user did not supply: ask "
     "'are you sure?' in second person, end with yes/no hint.\n"
     "  - Action has another missing parameter (`query`, `kind`, etc.): ask "
     "WHAT the user wants — e.g. 'What do you want to play?'.\n"
-    "  - Conversational query (no action match) with a clear factual "
-    "answer YOU know from your training — math, definitions, "
-    "translations, general knowledge, geography, history. Write the "
-    "answer directly. Do NOT answer questions about live data (current "
-    "time, today's weather, news) — leave `response` empty for those, "
-    "you'll only hallucinate.\n"
+    "  - Factual question (no action match) you can answer confidently "
+    "from your training — math, definitions, translations, general "
+    "knowledge, geography, history. Write the answer directly, briefly. "
+    "Do NOT answer questions about live data (current time, today's "
+    "weather, news) — leave `response` empty for those, you'll only "
+    "hallucinate. If you don't actually know the answer to a factual "
+    "question, say so plainly ('Nie wiem.' / 'I don't know.') rather "
+    "than inventing facts.\n"
+    "  - Small-talk / personal / opinion question ('do you like cats?', "
+    "'how are you?', 'what's your name?'): give a brief friendly "
+    "answer (≤ 2 sentences), in character as a helpful voice assistant. "
+    "Stay warm but concise.\n"
     "Always write `response` in the same language as the input transcript. "
     "For pure dictation (description, narrative, prose with no question "
     "and no command), leave `response` empty.\n"
+    "\n"
+    "Precedence between `response` and `actions`: when you can answer a "
+    "factual question confidently from training, populate `response` and "
+    "leave `actions` empty. Reserve `web_search` and `wikipedia_search` "
+    "for when the user EXPLICITLY asks to open a browser / look "
+    "something up on Wikipedia, OR when you genuinely don't know. Do "
+    "NOT emit BOTH a direct answer in `response` AND a search action — "
+    "pick one.\n"
     "\n"
     "When previous turns are provided as context, USE them to resolve "
     "follow-up questions like 'and Poland?' after 'what is the capital "
     "of France?' — treat the new input as if its referring expressions "
     "point at the prior turns. Don't repeat the entire prior question "
-    "back; just answer."
+    "back; just answer.\n"
+    "\n"
+    "Follow-up continuity: if the prior turn was answered via `response` "
+    "(no action), the follow-up almost certainly continues that Q&A — "
+    "answer it the same way (populate `response`, leave `actions` "
+    "empty). Do NOT switch to `wikipedia_search` / `web_search` just "
+    "because the follow-up is short, fragmentary, or names a specific "
+    "topic. Match the prior turn's answering mode."
 )
 
 
@@ -192,8 +213,25 @@ def _build_user_prompt(
         '  "Spotify zagraj" → {"actions": [{"phrase": "Spotify zagraj", "name": "spotify_search"}], "response": "Co chcesz odtworzyć w Spotify?"}\n'
         '  "play on Spotify" → {"actions": [{"phrase": "play on Spotify", "name": "spotify_search"}], "response": "What do you want to play on Spotify?"}\n'
         '  "what is the capital of France" → {"actions": [], "response": "Paris."}\n'
+        '  "co to jest Paryż?" → {"actions": [], "response": "Paryż to stolica Francji."}\n'
         '  "ile to siedem razy osiem" → {"actions": [], "response": "Pięćdziesiąt sześć."}\n'
+        '  "czy lubisz kotki?" → {"actions": [], "response": "Tak, lubię kotki — są urocze."}\n'
+        '  "how are you?" → {"actions": [], "response": "Doing well, thanks for asking. What can I help you with?"}\n'
+        '  "wikipedia, Paryż" → {"actions": [{"phrase": "wikipedia, Paryż", "name": "wikipedia_search", "params": {"query": "Paryż"}}]}\n'
+        '  "look up Paris on Wikipedia" → {"actions": [{"phrase": "look up Paris on Wikipedia", "name": "wikipedia_search", "params": {"query": "Paris"}}]}\n'
+        '  "google pogodę w Warszawie" → {"actions": [{"phrase": "google pogodę w Warszawie", "name": "web_search", "params": {"query": "pogoda w Warszawie"}}]}\n'
         '  "what time is it" → {"actions": []}    (live data — no response, model would hallucinate)\n'
+        '  "Ok, dzięki. Koniec." → {"actions": [{"phrase": "Ok, dzięki. Koniec.", "name": "cancel_session"}]}\n'
+        '  "that\'s all, thanks" → {"actions": [{"phrase": "that\'s all, thanks", "name": "cancel_session"}]}\n'
+        '  "Zakończę." → {"actions": [{"phrase": "Zakończę.", "name": "cancel_session"}]}\n'
+        '  "I want to cancel my subscription." → {"actions": []}    (dictated content, NOT meta-cancel)\n'
+        "\n"
+        "Follow-up examples (when prior conversation is shown above):\n"
+        '  prior: User "what is the capital of France?" / Assistant "Paris."\n'
+        '  now:   "and Poland?" → {"actions": [], "response": "Warsaw."}\n'
+        '  prior: User "Jaka jest stolica Francji?" / Assistant "Paryż."\n'
+        '  now:   "A Polski?" → {"actions": [], "response": "Warszawa."}\n'
+        "  Note how the follow-up gets answered directly — same mode as the prior turn — NOT dispatched to wikipedia_search.\n"
         "\n"
         f"Now analyze this transcript and return ONLY the JSON object:\n"
         f"Input: {json.dumps(transcript, ensure_ascii=False)}\n"

--- a/src/korder/ui/main_window.py
+++ b/src/korder/ui/main_window.py
@@ -408,6 +408,12 @@ class MainWindow(QMainWindow):
             self._dictation_via_wake = False
             return
         self._begin_dictation_lifecycle()
+        # Defensive: clear any history left behind by a parse that
+        # completed on the worker thread after the previous
+        # _stop_recording cleared. Cheap, idempotent — typically a
+        # no-op since stop already cleared.
+        if self._injector is not None:
+            self._injector.clear_op_parser_history()
         self._status.setText(t("status_listening"))
         self._osd.set_listening(write_mode=self._write_mode)
         # Opportunistic preload — kick the model load now (fire-and-
@@ -470,6 +476,13 @@ class MainWindow(QMainWindow):
         # transcription proceeds or short-circuits below. Whisper runs
         # off-thread; we don't want playback held down for the duration.
         self._end_dictation_lifecycle()
+        # End-of-session: drop the parser's conversation history so the
+        # next 'hey jarvis' (or hotkey toggle) starts fresh. Within ONE
+        # session, follow-ups like 'A Polski?' resolve against prior
+        # turns; across sessions, that resolution would be more
+        # confusing than helpful.
+        if self._injector is not None:
+            self._injector.clear_op_parser_history()
         self._emit_tray_state()
         if not transcribe_tail:
             self._status.setText(t("status_idle"))

--- a/src/korder/ui/main_window.py
+++ b/src/korder/ui/main_window.py
@@ -775,6 +775,23 @@ class MainWindow(QMainWindow):
                 QTimer.singleShot(150, self._auto_stop)
             return
 
+        # Conversational-answer path: the user asked a question with no
+        # registered action match, and Gemma populated `response` with
+        # a free-form reply (math, definitions, translation, general
+        # knowledge). Show the answer in the OSD instead of falling
+        # through to the "didn't get that" reset, then transition back
+        # to listening so the user can ask a follow-up.
+        if (
+            not command_fired
+            and self._pending_action is None
+            and self._last_llm_response
+            and self._recorder.is_recording
+        ):
+            answer = self._last_llm_response
+            self._last_llm_response = ""
+            QTimer.singleShot(120, lambda a=answer: self._show_conversational_answer(a))
+            return
+
         # Pure-dictation path: the LLM produced no command actions this
         # round (or auto-stop is off). If the recorder is still open and
         # there's no pending parameter expected, give the user a fresh
@@ -789,6 +806,45 @@ class MainWindow(QMainWindow):
             and self._recorder.is_recording
         ):
             QTimer.singleShot(700, self._reset_to_listening_after_miss)
+
+    def _show_conversational_answer(self, answer: str) -> None:
+        """Display Gemma's free-form reply for a no-action conversational
+        query (math, definition, translation, general knowledge).
+        Reuses the executing-progress visual treatment — italic, accent
+        color — so the answer reads as system feedback distinct from
+        the user's own dictated text. After a read window proportional
+        to the answer's length, transition back to listening so the
+        user can ask a follow-up. No-op if the recorder closed or
+        another state took over in the interim."""
+        if not self._recorder.is_recording:
+            return
+        if self._pending_action is not None:
+            return
+        print(f"[korder] conversational answer: {answer!r}", flush=True)
+        self._osd.set_executing_progress(answer)
+        # Read window: ~50 ms per character + 1.5 s minimum + 7 s
+        # ceiling. Long enough for Polish multi-clause sentences, short
+        # enough that an absent user doesn't sit on a stale answer.
+        read_ms = max(1500, min(7000, 1500 + 50 * len(answer)))
+        QTimer.singleShot(read_ms, self._reset_to_listening_after_answer)
+
+    def _reset_to_listening_after_answer(self) -> None:
+        """Mirror of _reset_to_listening_after_miss but for the path
+        where a conversational answer was just displayed. Same
+        end-state — fresh listening with placeholder — but expects to
+        be called from 'executing' rather than 'committed'."""
+        if not self._recorder.is_recording:
+            return
+        if self._pending_action is not None:
+            return
+        if self._osd._state.stateKind != "executing":
+            return  # user started a new utterance — let that flow win
+        # Skip past any audio captured while the user was reading.
+        self._committed_samples = self._recorder.snapshot().shape[0]
+        self._reset_partial_render_state()
+        self._last_partial_norm = ""
+        self._stability_count = 0
+        self._osd.set_listening(write_mode=self._write_mode)
 
     def _reset_to_listening_after_miss(self) -> None:
         """Transition from 'committed' to a fresh 'listening' with a

--- a/tests/test_intent_integration.py
+++ b/tests/test_intent_integration.py
@@ -36,6 +36,18 @@ def parser(integration_model: str) -> IntentParser:
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_parser_history(request):
+    """The parser is module-scoped (to keep ollama warm) but
+    accumulates conversation history across parses. Without a reset,
+    a later test sees prior tests' transcripts in its prompt, which
+    degrades accuracy. Clear before each test."""
+    p = request.getfixturevalue("parser") if "parser" in request.fixturenames else None
+    if p is not None:
+        p.clear_history()
+    yield
+
+
 # ---- Synonym recognition (the core user complaint) -----------------------
 
 @pytest.mark.parametrize("phrase", [

--- a/tests/test_intent_response.py
+++ b/tests/test_intent_response.py
@@ -144,6 +144,25 @@ def test_legitimate_confirm_param_passes_through():
     assert "callable" in kinds, f"expected the action to fire; got {ops!r}"
 
 
+def test_last_response_for_conversational_no_action_query():
+    """Pure-conversational queries — no action match but the LLM has
+    a factual answer — populate `response` and produce no ops besides
+    the original text. main_window's _show_conversational_answer
+    consumer detects this case (actions empty + last_response set)
+    and renders the reply in the OSD instead of the 'didn't get
+    that' reset."""
+    p, mock_urlopen = _patched_parser({
+        "actions": [],
+        "response": "Paris.",
+    })
+    with mock_urlopen:
+        ops = p.parse("what is the capital of France")
+    assert p.last_response == "Paris."
+    # Empty actions → text op for the original transcript (regex
+    # supplement runs but won't match either, so just the text).
+    assert ("text", "what is the capital of France") in ops
+
+
 def test_last_response_strips_whitespace():
     """Models sometimes wrap with leading/trailing whitespace —
     consumers display this directly so leading newlines look bad."""


### PR DESCRIPTION
## Summary

Three coordinated improvements to the LLM intent parser for a more conversational feel.

**1. Per-session conversation history.** Rolling Turn history (max 4) feeds back into the parser prompt so follow-ups like *"A Polski?"* resolve against the prior *"Jaka jest stolica Francji?"* answer. Scoped to a single dictation session via `clear_history` on `_stop_recording` (with a defensive clear on `_start_recording`). Plumbed through the existing `op_parser_*` callable pattern; regex parser is a no-op.

**2. Chattier responses.** `web_search` / `wikipedia_search` descriptions now require an explicit search verb — phrasings like *"co to jest X"*, *"tell me about X"*, *"kim był X"* are conversational and answered directly via the `response` field. System prompt gains a small-talk case, a precedence rule (no double-emit of response + search action), a follow-up continuity rule (match prior turn's mode), and a "don't invent facts — say you don't know" hedge against hallucinations.

**3. Graceful session end.** `cancel_session` covers both abort-flavor (*"nieważne"*, *"cancel that"*) and graceful-end-flavor (*"koniec"*, *"that's all"*, *"zakończ"*, *"we're done"*, *"stop listening"*) on both LLM and regex paths.

Anchoring examples in `_build_user_prompt` cover all three behaviors in Polish + English.

## Test plan

- [x] `uv run pytest -q` (174 unit tests green)
- [x] Manual: `hey jarvis` → factual question (*"Jaka jest stolica Polski?"*) → direct response, no Wikipedia
- [x] Manual: follow-ups (*"A Francja?"*, *"A Niemiec?"*) → continuity-mode direct answers
- [x] Manual: small-talk (*"Czy lubisz kotki?"*, *"A pieski?"*) → friendly response
- [x] Manual: explicit search (*"Wikipedia, X"*, *"google X"*) → still dispatches
- [x] Manual: graceful end (*"Ok, dzięki. Koniec."*, *"Zakończę."*) → cancels cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)