### PR TITLE
Migrate remaining prints to logging across audio/actions/UI

### DIFF
--- a/src/korder/actions/spotify.py
+++ b/src/korder/actions/spotify.py
@@ -28,10 +28,13 @@ omits it (no explicit cue in the utterance), the client searches all
 four types in one request and picks the closest name match to the
 query — see SpotifyClient.search.
 """
+import logging
 import shlex
 import subprocess
 import time
 from urllib.parse import quote
+
+log = logging.getLogger(__name__)
 
 from korder import config
 from korder.actions.base import Action, register
@@ -110,13 +113,13 @@ def _spotify_play_query(query: str, kind: str) -> None:
             ))
             time.sleep(_PROGRESS_DWELL_S)
             emit_progress(tf("progress_playing", name=name))
-            print(f"[korder] Spotify: playing {result['uri']} (kind={result.get('kind')}) for query {query!r}", flush=True)
+            log.info("Spotify: playing %s (kind=%s) for query %r", result['uri'], result.get('kind'), query)
             _open_uri_via_dbus_or_xdg(result["uri"])
             return
     # Fallback: open search UI, user clicks
     fallback_uri = f"spotify:search:{quote(query)}"
     emit_progress(tf("progress_no_match", query=query))
-    print(f"[korder] Spotify: no API result; opening search {fallback_uri}", flush=True)
+    log.info("Spotify: no API result; opening search %s", fallback_uri)
     _open_uri_via_dbus_or_xdg(fallback_uri)
 
 

--- a/src/korder/actions/system.py
+++ b/src/korder/actions/system.py
@@ -12,6 +12,7 @@ _confirm_op_factory below for the tri-state semantics.
 """
 from __future__ import annotations
 
+import logging
 import re
 import subprocess
 from typing import Callable
@@ -19,6 +20,8 @@ from typing import Callable
 from korder.actions.base import Action, register
 from korder.ui.i18n import t, tf
 from korder.ui.progress import emit_progress
+
+log = logging.getLogger(__name__)
 
 
 def _do_lock_screen() -> None:
@@ -36,7 +39,7 @@ def _do_lock_screen() -> None:
         )
     except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
         emit_progress(tf("progress_lock_failed", error=str(e)))
-        print(f"[korder] lock_screen: xdg-screensaver failed: {e}", flush=True)
+        log.error("lock_screen: xdg-screensaver failed: %s", e)
 
 
 register(Action(
@@ -156,7 +159,7 @@ def _do_shutdown() -> None:
         subprocess.run(["systemctl", "poweroff"], check=False, capture_output=True, timeout=5)
     except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
         emit_progress(tf("progress_power_failed", action=t("progress_shutting_down"), error=str(e)))
-        print(f"[korder] shutdown: systemctl poweroff failed: {e}", flush=True)
+        log.error("shutdown: systemctl poweroff failed: %s", e)
 
 
 def _do_reboot() -> None:
@@ -165,7 +168,7 @@ def _do_reboot() -> None:
         subprocess.run(["systemctl", "reboot"], check=False, capture_output=True, timeout=5)
     except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
         emit_progress(tf("progress_power_failed", action=t("progress_rebooting"), error=str(e)))
-        print(f"[korder] reboot: systemctl reboot failed: {e}", flush=True)
+        log.error("reboot: systemctl reboot failed: %s", e)
 
 
 def _do_suspend() -> None:
@@ -174,7 +177,7 @@ def _do_suspend() -> None:
         subprocess.run(["systemctl", "suspend"], check=False, capture_output=True, timeout=5)
     except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
         emit_progress(tf("progress_power_failed", action=t("progress_suspending"), error=str(e)))
-        print(f"[korder] sleep: systemctl suspend failed: {e}", flush=True)
+        log.error("sleep: systemctl suspend failed: %s", e)
 
 
 register(_confirmable_action(

--- a/src/korder/actions/web.py
+++ b/src/korder/actions/web.py
@@ -16,12 +16,15 @@ from the system locale (en or pl).
 from __future__ import annotations
 
 import locale
+import logging
 import subprocess
 from urllib.parse import quote
 
 from korder import config
 from korder.actions.base import Action, register
 from korder.ui.i18n import tf
+
+log = logging.getLogger(__name__)
 from korder.ui.progress import emit_progress
 
 
@@ -74,7 +77,7 @@ def _xdg_open(url: str, *, narrate_label: str, query: str) -> None:
         )
     except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
         emit_progress(tf("progress_xdg_failed", error=str(e)))
-        print(f"[korder] web action: xdg-open failed: {e}", flush=True)
+        log.error("web action: xdg-open failed: %s", e)
         return
     emit_progress(tf("progress_opened_search", engine=narrate_label))
 

--- a/src/korder/app.py
+++ b/src/korder/app.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 import argparse
+import logging
 import os
 import socket
 import sys
 import tempfile
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 # CRITICAL: rebrand the process and set audio-server identity env vars
 # BEFORE any import that transitively loads sounddevice/PortAudio.
@@ -122,12 +125,9 @@ def _setup_logging() -> None:
     drowning out korder's own INFO output by default while keeping
     everything visible when actually debugging.
 
-    This branch carries TTS + MPRIS code that uses the logging
-    module; without this setup, voice / pause / resume diagnostics
-    are silent in stderr while older print()-based code (intent.py,
-    main_window.py, etc.) keeps emitting. Backporting the full
-    print→logging migration is a separate concern."""
-    import logging
+    Korder's modules use logging.getLogger() throughout; without
+    this setup, INFO/DEBUG diagnostics route through Python's
+    lastResort handler (WARNING+ only) and are silent."""
     level_name = (os.environ.get("KORDER_LOG_LEVEL") or "INFO").strip().upper()
     level = getattr(logging, level_name, logging.INFO)
     if not isinstance(level, int):
@@ -164,7 +164,7 @@ def main() -> int:
     if _try_forward(forward_cmd):
         return 0
     if args.cmd is not None:
-        print(f"[korder] not running; start with `korder` first", file=sys.stderr)
+        log.error("not running; start with `korder` first")
         return 1
 
     return _run_app()
@@ -241,10 +241,7 @@ def _run_app() -> int:
         if show_triggers:
             flags.append("show-triggers")
         flag_str = f" [{', '.join(flags)}]" if flags else ""
-        print(
-            f"[korder] using LLM action parser ({cfg['inject']['llm_model']}){flag_str}",
-            file=sys.stderr,
-        )
+        log.info("using LLM action parser (%s)%s", cfg['inject']['llm_model'], flag_str)
 
     try:
         injector = make_backend(
@@ -256,7 +253,7 @@ def _run_app() -> int:
             op_parser_clear_history=op_parser_clear_history,
         )
     except InjectError as e:
-        print(f"[korder] injection disabled: {e}", file=sys.stderr)
+        log.error("injection disabled: %s", e)
         injector = None
 
     osd = OSDWindow()
@@ -338,7 +335,7 @@ def _build_wake_detector(cfg, recorder: MicRecorder):
             sample_rate=recorder.sample_rate,
         )
     except Exception as e:
-        print(f"[korder] wake: detector init failed: {e}", file=sys.stderr)
+        log.error("wake: detector init failed: %s", e)
         return None
     return detector
 
@@ -362,7 +359,7 @@ def _build_tts_engine(cfg):
             speed=speed,
         )
     except Exception as e:
-        print(f"[korder] tts: engine init failed: {e}", file=sys.stderr)
+        log.error("tts: engine init failed: %s", e)
         return None
     return engine
 
@@ -478,7 +475,7 @@ def _install_tray_icon_in_theme() -> None:
             _USER_ICON_PATH.parent.mkdir(parents=True, exist_ok=True)
             _USER_ICON_PATH.write_bytes(_TRAY_SVG.read_bytes())
     except OSError as e:
-        print(f"[korder] couldn't install tray icon: {e}", file=sys.stderr)
+        log.error("couldn't install tray icon: %s", e)
 
 
 def _install_desktop_entry() -> None:
@@ -503,7 +500,7 @@ def _install_desktop_entry() -> None:
         _USER_DESKTOP_PATH.parent.mkdir(parents=True, exist_ok=True)
         _USER_DESKTOP_PATH.write_bytes(src_bytes)
     except OSError as e:
-        print(f"[korder] couldn't install desktop entry: {e}", file=sys.stderr)
+        log.error("couldn't install desktop entry: %s", e)
 _TRAY_RENDER_SIZES = (16, 22, 24, 32, 48, 64)
 # Per-state foreground colors. idle uses the theme; the other two are
 # fixed accents so the user gets a consistent visual cue regardless of
@@ -546,10 +543,7 @@ def _start_ipc_server(window: MainWindow) -> QLocalServer:
     if not server.listen(SOCKET_NAME):
         QLocalServer.removeServer(SOCKET_NAME)
         if not server.listen(SOCKET_NAME):
-            print(
-                f"[korder] IPC server failed: {server.errorString()}",
-                file=sys.stderr,
-            )
+            log.error("IPC server failed: %s", server.errorString())
 
     def _on_new_connection() -> None:
         sock = server.nextPendingConnection()

--- a/src/korder/audio/capture.py
+++ b/src/korder/audio/capture.py
@@ -10,13 +10,15 @@ consumers (wake-word detector, VAD-on-tap, level meter, …) call
 the dictation flow.
 """
 from __future__ import annotations
-import sys
+import logging
 import threading
 import time
 from typing import Callable
 
 import numpy as np
 import sounddevice as sd
+
+log = logging.getLogger(__name__)
 
 
 FrameCallback = Callable[[np.ndarray], None]
@@ -62,7 +64,7 @@ class MicRecorder:
             try:
                 sub(chunk)
             except Exception as e:
-                print(f"[korder] mic subscriber error: {e}", flush=True, file=sys.stderr)
+                log.error("mic subscriber error: %s", e)
 
     def subscribe(self, fn: FrameCallback) -> None:
         """Attach a frame consumer. Opens the audio stream on the first
@@ -124,10 +126,7 @@ class MicRecorder:
                 last_exc = e
                 if not self._is_transient_pa_error(e):
                     raise
-                print(
-                    f"[korder] mic: InputStream construct failed (transient): {e}",
-                    flush=True, file=sys.stderr,
-                )
+                log.warning("mic: InputStream construct failed (transient): %s", e)
                 continue
             try:
                 stream.start()
@@ -142,10 +141,7 @@ class MicRecorder:
                     pass
                 if not self._is_transient_pa_error(e):
                     raise
-                print(
-                    f"[korder] mic: InputStream start failed (transient, will retry): {e}",
-                    flush=True, file=sys.stderr,
-                )
+                log.warning("mic: InputStream start failed (transient, will retry): %s", e)
                 continue
         # All retries exhausted.
         assert last_exc is not None

--- a/src/korder/audio/ducker.py
+++ b/src/korder/audio/ducker.py
@@ -20,9 +20,12 @@ not ducked is a no-op.
 """
 from __future__ import annotations
 import atexit
+import logging
 import re
 import subprocess
 import threading
+
+log = logging.getLogger(__name__)
 
 
 _VOLUME_RE = re.compile(r"Volume:\s+([\d.]+)")
@@ -64,17 +67,14 @@ class VolumeDucker:
                 return
             if self._set_volume(self._target):
                 self._saved = current
-                print(
-                    f"[korder] ducker: {current:.2f} → {self._target:.2f}",
-                    flush=True,
-                )
+                log.info("ducker: %.2f → %.2f", current, self._target)
 
     def restore(self) -> None:
         with self._lock:
             if self._saved is None:
                 return
             if self._set_volume(self._saved):
-                print(f"[korder] ducker: restored {self._saved:.2f}", flush=True)
+                log.info("ducker: restored %.2f", self._saved)
             # Clear saved state regardless — a failed restore call shouldn't
             # leave us pinned in "ducked" forever; the next duck() can re-read
             # whatever the user left things at.
@@ -96,7 +96,7 @@ class VolumeDucker:
                 check=True,
             )
         except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
-            print(f"[korder] ducker: get-volume failed: {e}", flush=True)
+            log.error("ducker: get-volume failed: %s", e)
             return None
         match = _VOLUME_RE.search(result.stdout)
         if match is None:
@@ -116,5 +116,5 @@ class VolumeDucker:
             )
             return True
         except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
-            print(f"[korder] ducker: set-volume failed: {e}", flush=True)
+            log.error("ducker: set-volume failed: %s", e)
             return False

--- a/src/korder/audio/wake.py
+++ b/src/korder/audio/wake.py
@@ -12,11 +12,13 @@ an ImportError at module load time, even if they don't have it
 installed.
 """
 from __future__ import annotations
-import sys
+import logging
 import threading
 
 import numpy as np
 from PySide6.QtCore import QObject, Signal
+
+log = logging.getLogger(__name__)
 
 
 class WakeWordDetector(QObject):
@@ -97,10 +99,9 @@ class WakeWordDetector(QObject):
             self._cooldown_frames = 0
         self._running = True
         self._recorder.subscribe(self._on_frame)
-        print(
-            f"[korder] wake: listening for {self._phrase!r} "
-            f"(sensitivity {self._sensitivity:.2f})",
-            flush=True, file=sys.stderr,
+        log.info(
+            "wake: listening for %r (sensitivity %.2f)",
+            self._phrase, self._sensitivity,
         )
 
     def stop(self) -> None:
@@ -113,7 +114,7 @@ class WakeWordDetector(QObject):
             self._recorder.unsubscribe(self._on_frame)
         except Exception:
             pass
-        print("[korder] wake: stopped listening", flush=True, file=sys.stderr)
+        log.info("wake: stopped listening")
 
     def _on_frame(self, chunk: np.ndarray) -> None:
         """MicRecorder subscriber callback. Accumulates frames until a
@@ -148,10 +149,9 @@ class WakeWordDetector(QObject):
                     self._cooldown_frames -= 1
             return
         if score >= self._sensitivity:
-            print(
-                f"[korder] wake: {self._phrase!r} fired "
-                f"(score={score:.3f} >= {self._sensitivity:.2f})",
-                flush=True, file=sys.stderr,
+            log.info(
+                "wake: %r fired (score=%.3f >= %.2f)",
+                self._phrase, score, self._sensitivity,
             )
             cooldown_chunks = int(
                 self._COOLDOWN_S * self._sample_rate / self.CHUNK_SAMPLES

--- a/src/korder/inject.py
+++ b/src/korder/inject.py
@@ -7,6 +7,7 @@ executes whatever op tuples come back. Backward compatibility shims
 the codebase and any external scripts keep working.
 """
 from __future__ import annotations
+import logging
 import shutil
 import subprocess
 import threading
@@ -14,6 +15,8 @@ import time
 
 from korder.actions.codes import KEY_LCTRL, KEY_V
 from korder.actions.parser import split_into_ops as _split_into_ops  # noqa: F401  (re-export)
+
+log = logging.getLogger(__name__)
 
 
 class InjectError(RuntimeError):
@@ -188,7 +191,7 @@ class YdotoolBackend:
         try:
             fn()
         except Exception as e:
-            print(f"[korder] callable action failed: {e}", flush=True)
+            log.error("callable action failed: %s", e)
 
     def _run_system_volume(self, payload) -> None:
         """Adjust the default audio sink directly via wpctl. Replaces the
@@ -205,7 +208,7 @@ class YdotoolBackend:
         try:
             direction, step_pct = payload
         except (TypeError, ValueError):
-            print(f"[korder] system_volume: bad payload {payload!r}", flush=True)
+            log.error("system_volume: bad payload %r", payload)
             return
         if direction == "up":
             args = ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", f"{step_pct}%+"]
@@ -214,12 +217,12 @@ class YdotoolBackend:
         elif direction == "mute_toggle":
             args = ["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"]
         else:
-            print(f"[korder] system_volume: unknown direction {direction!r}", flush=True)
+            log.warning("system_volume: unknown direction %r", direction)
             return
         try:
             subprocess.run(args, check=False, capture_output=True, timeout=2.0)
         except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-            print(f"[korder] system_volume {direction} failed: {e}", flush=True)
+            log.error("system_volume %s failed: %s", direction, e)
 
     def _run_subprocess(self, args: list[str]) -> None:
         """Issue a system command (volume, media, etc.) — fire and forget.
@@ -235,7 +238,7 @@ class YdotoolBackend:
                 timeout=5,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-            print(f"[korder] subprocess action {args!r} failed: {e}", flush=True)
+            log.error("subprocess action %r failed: %s", args, e)
 
     def _should_paste(self, text: str) -> bool:
         if not self._has_wl_copy:

--- a/src/korder/intent.py
+++ b/src/korder/intent.py
@@ -15,7 +15,7 @@ or any phrase isn't found in the input.
 """
 from __future__ import annotations
 import json
-import sys
+import logging
 import threading
 import time
 import urllib.error
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 
 from korder.actions.base import all_actions, get_action
 from korder.actions.parser import split_into_ops
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -296,17 +298,9 @@ class IntentParser:
         runs on a daemon thread."""
         already_loaded = self.is_model_loaded()
         if already_loaded:
-            print(
-                f"[korder] warm-up: {self.model} already resident — "
-                f"keep_alive bumped",
-                flush=True, file=sys.stderr,
-            )
+            log.info("warm-up: %s already resident — keep_alive bumped", self.model)
         else:
-            print(
-                f"[korder] warm-up: {self.model} not resident — "
-                f"kicking off background load",
-                flush=True, file=sys.stderr,
-            )
+            log.info("warm-up: %s not resident — kicking off background load", self.model)
         payload = {
             "model": self.model,
             "prompt": "",
@@ -326,17 +320,11 @@ class IntentParser:
             except Exception as e:
                 # Warm-up is opportunistic; failure here is fine —
                 # the actual parse call will surface a real error.
-                print(
-                    f"[korder] warm-up of {self.model} failed: {e}",
-                    flush=True, file=sys.stderr,
-                )
+                log.warning("warm-up of %s failed: %s", self.model, e)
                 return
             elapsed_ms = (time.perf_counter() - t0) * 1000.0
             verb = "bumped" if already_loaded else "loaded"
-            print(
-                f"[korder] warm-up: {self.model} {verb} in {elapsed_ms:.0f} ms",
-                flush=True, file=sys.stderr,
-            )
+            log.info("warm-up: %s %s in %.0f ms", self.model, verb, elapsed_ms)
         threading.Thread(target=_send, daemon=True).start()
 
     def is_model_loaded(self) -> bool:
@@ -363,7 +351,7 @@ class IntentParser:
         next session starts fresh — yesterday's 'and Polish?' shouldn't
         resolve against last week's France question."""
         if self._history:
-            print(f"[korder] history cleared ({len(self._history)} turns)", flush=True, file=sys.stderr)
+            log.info("history cleared (%d turns)", len(self._history))
         self._history = []
 
     def _push_turn(
@@ -397,7 +385,7 @@ class IntentParser:
         try:
             actions = self._call_ollama(transcript)
         except Exception as e:
-            print(f"[korder] intent LLM failed, falling back to regex: {e}", flush=True, file=sys.stderr)
+            log.warning("intent LLM failed, falling back to regex: %s", e)
             return split_into_ops(transcript)
         # Record this turn BEFORE the regex-supplement / segmentation
         # path forks — history is about what the LLM saw and produced,
@@ -415,7 +403,7 @@ class IntentParser:
         # to confirm or cancel.
         _scrub_hallucinated_confirm(transcript, actions)
 
-        print(f"[korder] LLM actions for {transcript!r}: {actions!r}", flush=True, file=sys.stderr)
+        log.info("LLM actions for %r: %r", transcript, actions)
 
         # Supplement: if LLM came back empty but the regex parser sees an
         # actual registered trigger phrase, use the regex result. Catches
@@ -434,16 +422,15 @@ class IntentParser:
                 return [("text", transcript)] if transcript else []
             regex_ops = split_into_ops(transcript)
             if any(op[0] != "text" for op in regex_ops):
-                print(
-                    f"[korder] LLM found no actions; regex caught triggers, using regex: {regex_ops!r}",
-                    flush=True,
-                    file=sys.stderr,
+                log.info(
+                    "LLM found no actions; regex caught triggers, using regex: %r",
+                    regex_ops,
                 )
                 return regex_ops
 
         ops = segment_input_by_actions(transcript, actions)
         if ops is None:
-            print(f"[korder] LLM action phrase not found in input, falling back to regex", flush=True, file=sys.stderr)
+            log.info("LLM action phrase not found in input, falling back to regex")
             return split_into_ops(transcript)
 
         # Second-chance regex backstop: LLM emitted SOMETHING in actions
@@ -458,14 +445,13 @@ class IntentParser:
         if actions and ops and all(op[0] == "text" for op in ops):
             regex_ops = split_into_ops(transcript)
             if any(op[0] != "text" for op in regex_ops):
-                print(
-                    f"[korder] LLM emitted malformed actions; regex caught triggers, using regex: {regex_ops!r}",
-                    flush=True,
-                    file=sys.stderr,
+                log.info(
+                    "LLM emitted malformed actions; regex caught triggers, using regex: %r",
+                    regex_ops,
                 )
                 return regex_ops
 
-        print(f"[korder] segmented ops: {ops!r}", flush=True, file=sys.stderr)
+        log.info("segmented ops: %r", ops)
         return ops
 
     def _call_ollama(self, transcript: str) -> list:
@@ -512,11 +498,7 @@ class IntentParser:
         thinking = (body.get("thinking") or "").strip()
         self.last_thinking = thinking
         if thinking:
-            print(
-                f"[korder] gemma thinking for {transcript!r}:\n  {thinking}",
-                flush=True,
-                file=sys.stderr,
-            )
+            log.info("gemma thinking for %r:\n  %s", transcript, thinking)
         raw = body.get("response", "").strip()
         parsed = _extract_json_object(raw)
         # Reset last_response — if the new parse omits it, we don't
@@ -530,17 +512,11 @@ class IntentParser:
             response_field = parsed.get("response")
             if isinstance(response_field, str) and response_field.strip():
                 self.last_response = response_field.strip()
-                print(
-                    f"[korder] LLM response for {transcript!r}: {self.last_response!r}",
-                    flush=True, file=sys.stderr,
-                )
+                log.info("LLM response for %r: %r", transcript, self.last_response)
             context_field = parsed.get("context")
             if isinstance(context_field, str) and context_field.strip():
                 self.last_context = context_field.strip()
-                print(
-                    f"[korder] LLM context for {transcript!r}: {self.last_context!r}",
-                    flush=True, file=sys.stderr,
-                )
+                log.info("LLM context for %r: %r", transcript, self.last_context)
             if isinstance(parsed.get("actions"), list):
                 return parsed["actions"]
         if isinstance(parsed, list):
@@ -568,10 +544,9 @@ def _scrub_hallucinated_confirm(transcript: str, actions: list) -> None:
         if not confirm or not isinstance(confirm, str):
             continue
         if confirm.strip().lower() not in lower:
-            print(
-                f"[korder] cleared hallucinated confirm={confirm!r} for "
-                f"action {action.get('name')!r} — not present in transcript",
-                flush=True, file=sys.stderr,
+            log.warning(
+                "cleared hallucinated confirm=%r for action %r — not present in transcript",
+                confirm, action.get("name"),
             )
             params["confirm"] = ""
 

--- a/src/korder/spotify_client.py
+++ b/src/korder/spotify_client.py
@@ -16,12 +16,15 @@ Setup (one-time, ~2 min):
 from __future__ import annotations
 import base64
 import json
+import logging
 import threading
 import time
 import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
+
+log = logging.getLogger(__name__)
 
 
 _TOKEN_URL = "https://accounts.spotify.com/api/token"
@@ -157,7 +160,7 @@ class SpotifyClient:
             with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
-            print(f"[korder] Spotify search ({type_param}) failed: {e}", flush=True)
+            log.error("Spotify search (%s) failed: %s", type_param, e)
             return None
 
     # Backward-compat alias for callers that imported the old name.
@@ -185,7 +188,7 @@ class SpotifyClient:
                 with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
                     body = json.loads(resp.read().decode("utf-8"))
             except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
-                print(f"[korder] Spotify token fetch failed: {e}", flush=True)
+                log.error("Spotify token fetch failed: %s", e)
                 return None
             self._token = body.get("access_token")
             self._token_expires_at = now + float(body.get("expires_in", 3600))

--- a/src/korder/ui/main_window.py
+++ b/src/korder/ui/main_window.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-import sys
 import numpy as np
 from PySide6.QtCore import Qt, QThread, QTimer, Signal
 from PySide6.QtGui import QCloseEvent
@@ -97,10 +96,7 @@ class _InjectWorker(QThread):
                 # a separate Loading state so the user understands the
                 # extra second isn't reasoning, it's paging the model in.
                 if self._injector.is_slow_parser and not self._injector.is_op_parser_warm():
-                    print(
-                        "[korder] parse: model not resident — cold start, showing Loading",
-                        flush=True, file=sys.stderr,
-                    )
+                    log.info("parse: model not resident — cold start, showing Loading")
                     self.loading_started.emit()
                 else:
                     self.parse_started.emit()
@@ -123,10 +119,7 @@ class _InjectWorker(QThread):
                     response = last_response_fn() or ""
                 self.parse_response.emit(response)
                 if self._injector.is_slow_parser:
-                    print(
-                        f"[korder] parse: completed in {(time.perf_counter()-t0)*1000:.0f} ms",
-                        flush=True, file=sys.stderr,
-                    )
+                    log.info("parse: completed in %.0f ms", (time.perf_counter()-t0)*1000)
                 self.parse_done.emit()
             # Cancel takes priority over everything else in the batch.
             # When the user said 'cancel' / 'nevermind', drop any pending
@@ -135,10 +128,7 @@ class _InjectWorker(QThread):
             # the OSD has cleaned up its Thinking state; the main thread
             # handles the rest via cancel_requested.
             if any(op[0] == "cancel" for op in ops):
-                print(
-                    "[korder] cancel_session: aborting batch, signalling main thread",
-                    flush=True, file=sys.stderr,
-                )
+                log.info("cancel_session: aborting batch, signalling main thread")
                 self.cancel_requested.emit()
                 return
             filtered: list[tuple] = []
@@ -365,7 +355,7 @@ class MainWindow(QMainWindow):
         try:
             self._wake_detector.start()
         except Exception as e:
-            print(f"[korder] wake: failed to start: {e}", flush=True, file=sys.stderr)
+            log.error("wake: failed to start: %s", e)
             self.statusBar().showMessage(f"Wake-word: {e}", 8000)
             return
         self._emit_tray_state()
@@ -395,7 +385,7 @@ class MainWindow(QMainWindow):
         self._sync_button()
 
     def _on_wake_error(self, msg: str) -> None:
-        print(f"[korder] wake: {msg}", flush=True, file=sys.stderr)
+        log.error("wake: %s", msg)
 
     def _on_wake_idle_timeout(self) -> None:
         """No speech arrived within wake_idle_timeout_s of a wake fire.
@@ -403,10 +393,7 @@ class MainWindow(QMainWindow):
         so the OSD doesn't sit open on a false positive."""
         if not self._recorder.is_recording:
             return
-        print(
-            "[korder] wake: dictation idle-timeout — canceling, returning to wake-listen",
-            flush=True, file=sys.stderr,
-        )
+        log.info("wake: dictation idle-timeout — canceling, returning to wake-listen")
         self.cancel_recording()
 
     def _emit_tray_state(self) -> None:
@@ -734,13 +721,10 @@ class MainWindow(QMainWindow):
         if text is None or not self._recorder.is_recording:
             return
         locked, flux = _split_at_locked_prefix(self._last_displayed_partial, text)
-        if os.environ.get("KORDER_DEBUG_OSD") == "1":
-            print(
-                f"[korder.osd] locked={locked!r} flux={flux!r} "
-                f"(prev={self._last_displayed_partial!r}, curr={text!r})",
-                file=sys.stderr,
-                flush=True,
-            )
+        log.debug(
+            "osd locked=%r flux=%r (prev=%r, curr=%r)",
+            locked, flux, self._last_displayed_partial, text,
+        )
         # No usable lock yet (first partial of the segment, or revision):
         # fall back to single-color render.
         if locked:
@@ -821,17 +805,14 @@ class MainWindow(QMainWindow):
         # previous worker emits pending_action — losing the "next text
         # commit is my parameter" wiring. _reap_inject drains the queue.
         if self._inject_workers:
-            print(
-                f"[korder] commit {text!r} queued (workers in flight={len(self._inject_workers)}, pending={self._pending_action!r})",
-                flush=True,
+            log.info(
+                "commit %r queued (workers in flight=%d, pending=%r)",
+                text, len(self._inject_workers), self._pending_action,
             )
             self._commit_queue.append(text)
             return
 
-        print(
-            f"[korder] commit {text!r} immediate (pending={self._pending_action!r})",
-            flush=True,
-        )
+        log.info("commit %r immediate (pending=%r)", text, self._pending_action)
         self._process_commit(text)
 
     def _process_commit(self, text: str) -> None:
@@ -959,7 +940,7 @@ class MainWindow(QMainWindow):
             return
         if self._pending_action is not None:
             return
-        print(f"[korder] conversational answer: {answer!r}", flush=True)
+        log.info("conversational answer: %r", answer)
         self._osd.set_executing_progress(answer)
         # Visual read window: ~50 ms per character + 1.5 s minimum,
         # 7 s ceiling. Long enough for Polish multi-clause sentences,
@@ -1087,7 +1068,7 @@ class MainWindow(QMainWindow):
         cancel path does, and clear any pending-action / auto-stop
         bookkeeping so the next session starts fresh. Also stops any
         in-flight TTS — cancel means cancel everything."""
-        print("[korder] cancel_session: aborting recording on user request", flush=True)
+        log.info("cancel_session: aborting recording on user request")
         self._auto_stop_pending = False
         self._pending_action = None
         if self._tts is not None:
@@ -1232,7 +1213,7 @@ class MainWindow(QMainWindow):
         into) doesn't get flushed through Whisper as a spurious final
         commit when the mic closes."""
         if self._recorder.is_recording:
-            print("[korder] auto-stop after command", flush=True)
+            log.info("auto-stop after command")
             self._stop_recording(transcribe_tail=False)
             self._sync_button()
 
@@ -1247,7 +1228,7 @@ class MainWindow(QMainWindow):
     def _on_pending_action(self, action_name: str) -> None:
         """Worker reports a parameterized action with empty params —
         wait for the next commit and treat it as the parameter."""
-        print(f"[korder] pending action set: {action_name!r}", flush=True)
+        log.info("pending action set: %r", action_name)
         self._pending_action = action_name
         self._pending_action_time = time.time()
         action = get_action(action_name)
@@ -1337,10 +1318,7 @@ class MainWindow(QMainWindow):
         # worker to fully finish before starting the next.
         if not self._inject_workers and self._commit_queue:
             next_text = self._commit_queue.pop(0)
-            print(
-                f"[korder] draining queue: {next_text!r} (pending={self._pending_action!r})",
-                flush=True,
-            )
+            log.info("draining queue: %r (pending=%r)", next_text, self._pending_action)
             self._process_commit(next_text)
 
     def _on_fail(self, msg: str) -> None:

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -103,8 +103,11 @@ def test_stream_stays_open_until_last_subscriber_leaves(recorder):
     assert rec._stream is None
 
 
-def test_subscriber_error_does_not_kill_others(recorder, capsys):
-    """One bad subscriber shouldn't deny the others their frames."""
+def test_subscriber_error_does_not_kill_others(recorder, caplog):
+    """One bad subscriber shouldn't deny the others their frames.
+    Uses caplog (not capsys) since the error now routes through
+    the logging module rather than direct stderr writes."""
+    import logging
     rec, _stream, _calls = recorder
     seen: list[float] = []
 
@@ -113,11 +116,11 @@ def test_subscriber_error_does_not_kill_others(recorder, capsys):
 
     rec.subscribe(bad)
     rec.subscribe(lambda c: seen.append(float(c[0])))
-    rec._callback(_frame(fill=0.7), 160, None, None)
+    with caplog.at_level(logging.ERROR, logger="korder.audio.capture"):
+        rec._callback(_frame(fill=0.7), 160, None, None)
 
     assert seen == [pytest.approx(0.7)]
-    err = capsys.readouterr().err
-    assert "mic subscriber error" in err and "boom" in err
+    assert "mic subscriber error" in caplog.text and "boom" in caplog.text
 
 
 def test_unsubscribe_unknown_callable_is_noop(recorder):


### PR DESCRIPTION
## Summary

The TTS branch (#14) shipped the logging infrastructure — `_setup_logging()` in `app.py:main()`, the third-party-quieting logic, and a few converted modules. This PR finishes the job: every `print(...)` call across audio/actions/UI/intent now routes through `logging.getLogger(__name__)`.

12 modules touched, 11 source files + 1 test fix:
- `audio/`: ducker.py, capture.py, wake.py — full conversion
- `intent.py` — warm-up + parse trace + history + LLM response/context lines
- `inject.py`, `spotify_client.py`, `app.py` — error paths
- `actions/`: web.py, spotify.py, system.py — error + info paths
- `ui/main_window.py` — biggest one: parse cold-start, commit-queue dispatch, pending-action, conversational answer, auto-stop, draining queue, OSD locked-prefix tracker (now log.debug, replacing the hand-rolled `KORDER_DEBUG_OSD` env-var gate)

## Level rules applied per call site

| Level | Examples |
|---|---|
| `log.info` | warm-up state, ducker delta, commit dispatch, auto-stop, pending-action set, history cleared, parse completed, segmented ops |
| `log.warning` | LLM fallback to regex, hallucinated confirm scrubbed, PortAudio transient retry, unknown direction |
| `log.error` | subprocess failures, IPC server failure, wake init, Spotify API failures, mic subscriber error |
| `log.debug` | OSD locked-prefix tracker (was env-var gated; now KORDER_LOG_LEVEL=DEBUG enables it alongside everything else) |

## Test plan

- [x] `uv run pytest -m 'not ollama'` — 221/221 pass.
- [x] `test_subscriber_error_does_not_kill_others` switched from `capsys` to `caplog` since the error now goes through logging instead of direct stderr writes.
- [ ] Reviewer: `KORDER_LOG_LEVEL=DEBUG uv run korder` should show `[korder.ui.main_window] DEBUG: osd locked=...` lines (replacing the old `KORDER_DEBUG_OSD=1` env-var path).
- [ ] Reviewer: default-level launch should show `[korder.module] message` consistently — no more `[korder] message` prints mixed with the structured ones.

## Related

This was the last piece of work parked on `feat/at-spi-and-vision-actions`. Pulling it out as a standalone PR so it can ship without waiting on the click-action work (issues #12, #13). Once merged, only the click-action specific code remains on that branch — easier to revisit when the Wayland a11y story or the vision-grounding accuracy improves enough to make it worth shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)